### PR TITLE
[Kata] Strip comments 

### DIFF
--- a/docs/instructions/codewars/StripComments.md
+++ b/docs/instructions/codewars/StripComments.md
@@ -1,0 +1,61 @@
+Complete the solution so that it strips all text that follows any of a set of comment markers passed in. Any whitespace at the end of the line should also be stripped out.
+
+**Example:**
+
+Given an input string of:
+
+    apples, pears # and bananas
+    grapes
+    bananas !apples
+    
+
+The output expected would be:
+
+    apples, pears
+    grapes
+    bananas
+    
+
+The code would be called like so:
+
+    var result = solution("apples, pears # and bananas\ngrapes\nbananas !apples", ["#", "!"])
+    // result should == "apples, pears\ngrapes\nbananas"
+    
+
+    var result = solution("apples, pears # and bananas\ngrapes\nbananas !apples", charArrayOf('#', '!'))
+    // result should == "apples, pears\ngrapes\nbananas"
+    
+
+    result = solution("apples, pears # and bananas\ngrapes\nbananas !apples", ["#", "!"])
+    # result should == "apples, pears\nograpes\nbananas"
+    
+
+    result = solution("apples, pears # and bananas\ngrapes\nbananas !apples", ["#", "!"])
+    # result should == "apples, pears\ngrapes\nbananas"
+    
+
+    result = solution("apples, pears # and bananas\ngrapes\nbananas !apples", ["#", "!"])
+    # result should == "apples, pears\ngrapes\nbananas"
+    
+
+    result = solution("apples, pears # and bananas\ngrapes\nbananas !apples", ["#", "!"])
+    # result should == "apples, pears\ngrapes\nbananas"
+    
+
+    string stripped = StripCommentsSolution.StripComments("apples, pears # and bananas\ngrapes\nbananas !apples", new [] { "#", "!" })
+    // result should == "apples, pears\ngrapes\nbananas"
+    
+
+    result = stripcomments("apples, pears # and bananas\ngrapes\nbananas !apples", ["#", "!"])
+    # result should == "apples, pears\ngrapes\nbananas"
+    
+
+* * *
+
+Algorithms
+
+Strings
+
+* * *
+
+  

--- a/src/csharp/CodingKata.Exercise.Tests/CodeWars/StripCommentsTests.cs
+++ b/src/csharp/CodingKata.Exercise.Tests/CodeWars/StripCommentsTests.cs
@@ -1,0 +1,32 @@
+﻿using CodingKata.Exercise.CodeWars.StripComments;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CodingKata.Exercise.Tests.CodeWars
+{
+    public class StripCommentsTests
+    {
+        private Kata _sut;
+
+        public StripCommentsTests()
+        {
+            _sut = new Kata();
+        }
+
+        [Theory]
+        [InlineData("apples, pears # and bananas\ngrapes\nbananas !apples", new string[] { "#", "!" }, "apples, pears\ngrapes\nbananas")]
+        [InlineData("a #b\nc\nd $e f g", new string[] { "#", "$" }, "a\nc\nd")]
+        [InlineData("a \n b \nc ", new string[] { "#", "$" }, "a\n b\nc")]
+        [InlineData("\n\nFD\n\nDE\n\n\n\n\nB", new string[] { "#", "$" }, "\n\nFD\n\nDE\n\n\n\n\nB")]
+        [InlineData("\nC\n\n\nE\n\nC\n\nE\n\nF\n\nE\n\nEB\n\nDF\n\nE\n\nCE\n\nD\n\nC\n\n\n\nD\n\n\n\n\n\nB\n\nEE\n\n\n\n\n", new string[] { "#", "$" }, "\nC\n\n\nE\n\nC\n\nE\n\nF\n\nE\n\nEB\n\nDF\n\nE\n\nCE\n\nD\n\nC\n\n\n\nD\n\n\n\n\n\nB\n\nEE\n\n\n\n\n")]
+        public void TaskBasicCase(string input, string[] commentSymbols, string expected)
+        {
+            _sut.StripComments(input, commentSymbols).Should().Be(expected);
+        }
+    }
+}

--- a/src/csharp/CodingKata.Exercise/CodeWars/Benchmarks/StripCommentsBenchmark.cs
+++ b/src/csharp/CodingKata.Exercise/CodeWars/Benchmarks/StripCommentsBenchmark.cs
@@ -1,0 +1,31 @@
+﻿using BenchmarkDotNet.Attributes;
+using CodingKata.Exercise.Benchmark;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodingKata.Exercise.CodeWars.Benchmarks
+{
+    public class StripCommentsBenchmark : IBestVoteComparisonBenchmark
+    {
+        [Params("apples, pears # and bananas\ngrapes\nbananas !apples", "a #b\nc\nd $e f g")]
+       
+        public string Input { get; set; }
+        [Params(new [] { "#", "!" }, new [] { "#", "$" })]
+        public string[] CommentSymbols { get; set; }
+
+        [Benchmark(Baseline = true)]
+        public void MySolution()
+        {
+            new StripComments.Kata().StripComments(Input, CommentSymbols);
+        }
+
+        [Benchmark]
+        public void BestVote()
+        {
+            new StripComments.KataBestVote().StripComments(Input, CommentSymbols);
+        }
+    }
+}

--- a/src/csharp/CodingKata.Exercise/CodeWars/StripComments.cs
+++ b/src/csharp/CodingKata.Exercise/CodeWars/StripComments.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace CodingKata.Exercise.CodeWars.StripComments
+{
+    public interface IStripCommentsKata
+    {
+        string StripComments(string text, string[] commentSymbols);
+    }
+
+    public class Kata : IStripCommentsKata
+    {
+        public string StripComments(string text, string[] commentSymbols)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return string.Empty;
+            }
+
+            var regex = new Regex($"(?m) *?([{Regex.Escape(string.Join("", commentSymbols))}].*)?$");
+            return regex.Replace(text, string.Empty);
+
+        }
+
+    }
+
+    public class KataBestVote : IStripCommentsKata
+    {
+        public string StripComments(string text, string[] commentSymbols)
+        {
+            string[] lines = text.Split(new[] { "\n" }, StringSplitOptions.None);
+            lines = lines.Select(x => x.Split(commentSymbols, StringSplitOptions.None).First().TrimEnd()).ToArray();
+            return string.Join("\n", lines);
+        }
+    }
+}

--- a/src/csharp/CodingKata.Exercise/Program.cs
+++ b/src/csharp/CodingKata.Exercise/Program.cs
@@ -13,6 +13,7 @@ namespace CodingKata.Exercise
             BenchmarkDotNet.Running.BenchmarkRunner.Run<MorseCodeDecoderBenchmark>(DefaultConfig());
             BenchmarkDotNet.Running.BenchmarkRunner.Run<MorseCodeDecoderAdvanceBenchmark>(DefaultConfig());
             BenchmarkDotNet.Running.BenchmarkRunner.Run<MorseCodeDecoderRealLifeBenchmark>(DefaultConfig());
+            BenchmarkDotNet.Running.BenchmarkRunner.Run<StripCommentsBenchmark>(DefaultConfig());
         }
 
         private static ManualConfig DefaultConfig()


### PR DESCRIPTION

|     Method |                Input | CommentSymbols |       Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
|----------- |--------------------- |--------------- |-----------:|---------:|---------:|------:|-------:|----------:|
| MySolution |      a #b\nc\nd $e f g |      String[2] | 5,980.7 ns | 57.44 ns | 53.73 ns |  1.00 | 1.3733 |   4,312 B |
| MySolution |      a #b\nc\nd $e f g |      String[2] | 4,914.2 ns | 67.86 ns | 63.48 ns |  0.82 | 1.3580 |   4,280 B |
|   BestVote |      a #b\nc\nd $e f g |      String[2] |   477.1 ns |  3.65 ns |  3.23 ns |  0.08 | 0.1960 |     616 B |
|   BestVote |      a #b\nc\nd $e f g |      String[2] |   521.8 ns |  5.07 ns |  4.49 ns |  0.09 | 0.2213 |     696 B |
| MySolution | apple(...)pples [50] |      String[2] | 8,568.6 ns | 79.64 ns | 70.60 ns |  1.00 | 1.3733 |   4,344 B |
| MySolution | apple(...)pples [50] |      String[2] | 9,220.7 ns | 69.18 ns | 64.71 ns |  1.08 | 1.3733 |   4,344 B |
|   BestVote | apple(...)pples [50] |      String[2] |   699.8 ns |  5.33 ns |  4.99 ns |  0.08 | 0.2956 |     928 B |
|   BestVote | apple(...)pples [50] |      String[2] |   656.6 ns |  6.09 ns |  5.70 ns |  0.08 | 0.2594 |     816 B |