### PR TITLE
Range Extraction kata

### DIFF
--- a/docs/instructions/codewars/RangeExtraction.md
+++ b/docs/instructions/codewars/RangeExtraction.md
@@ -1,0 +1,76 @@
+A format for expressing an ordered list of integers is to use a comma separated list of either
+
+*   individual integers
+*   or a range of integers denoted by the starting integer separated from the end integer in the range by a dash, '-'. The range includes all integers in the interval including both endpoints. It is not considered a range unless it spans at least 3 numbers. For example "12,13,15-17"
+
+Complete the solution so that it takes a list of integers in increasing order and returns a correctly formatted string in the range format.
+
+**Example:**
+
+    solution([-6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20]);
+    // returns "-6,-3-1,3-5,7-11,14,15,17-20"
+    
+
+    solution([-6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20])
+    # returns "-6,-3-1,3-5,7-11,14,15,17-20"
+    
+
+    solution([-6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20])
+    # returns "-6,-3-1,3-5,7-11,14,15,17-20"
+    
+
+    solution([-6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20])
+    # returns "-6,-3-1,3-5,7-11,14,15,17-20"
+    
+
+    Solution.rangeExtraction(new int[] {-6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20})
+    # returns "-6,-3-1,3-5,7-11,14,15,17-20"
+    
+
+    RangeExtraction.Extract(new[] {-6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20});
+    # returns "-6,-3-1,3-5,7-11,14,15,17-20"
+    
+
+    range_extraction({-6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20});
+    // returns "-6,-3-1,3-5,7-11,14,15,17-20"
+    
+
+    range_extraction((const []){-6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20}, 20);
+    /* returns "-6,-3-1,3-5,7-11,14,15,17-20" */
+    
+
+    nums:  dd  -6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20
+    
+    mov rdi, nums
+    mov rsi, 20
+    call range_extraction
+    ; RAX <- `-6,-3-1,3-5,7-11,14,15,17-20\0`
+    
+
+    rangeextraction([-6 -3 -2 -1 0 1 3 4 5 7 8 9 10 11 14 15 17 18 19 20])
+    # returns "-6,-3-1,3-5,7-11,14,15,17-20"
+    
+
+    solution(List(-6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20))
+    // "-6,-3-1,3-5,7-11,14,15,17-20"
+    
+
+    (solution '(-6 -3 -2 -1 0 1 3 4 5 7 8 9 10 11 14 15 17 18 19 20))
+    ; returns "-6,-3-1,3-5,7-11,14,15,17-20"
+    
+
+    solution([-6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20])
+    // returns '-6,-3-1,3-5,7-11,14,15,17-20'
+    
+
+_Courtesy of rosettacode.org_
+
+* * *
+
+Algorithms
+
+String Formatting
+
+Formatting
+
+Strings

--- a/src/csharp/CodingKata.Exercise.Tests/CodeWars/RangeExtractionTests.cs
+++ b/src/csharp/CodingKata.Exercise.Tests/CodeWars/RangeExtractionTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CodingKata.Exercise.CodeWars.RangeExtraction;
+using FluentAssertions;
+using Xunit;
+
+namespace CodingKata.Exercise.Tests.CodeWars
+{
+    public class RangeExtractionTests
+    {
+        private Kata _sut;
+
+        public RangeExtractionTests()
+        {
+            _sut = new Kata();
+        }
+
+        [Theory]
+        [InlineData(new[] { 1, 2 }, "1,2")]
+        [InlineData(new[] { 1, 2, 3 }, "1-3")]
+        [InlineData(new[] { -6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20 }, "-6,-3-1,3-5,7-11,14,15,17-20")]
+        [InlineData(new[] { -3, -2, -1, 2, 10, 15, 16, 18, 19, 20 }, "-3--1,2,10,15,16,18-20")]
+        [InlineData(new[] { 47, 49, 50, 52, 53, 55 }, "47,49,50,52,53,55")]
+        [InlineData(new[] { 83, 85, 87, 88, 89, 91, 92 }, "83,85,87-89,91,92")]
+        public void SimpleTests(int[] numbers, string expected)
+        {
+           _sut.Extract(numbers).Should().Be(expected);
+        }
+
+       
+        
+        [Theory]
+        [InlineData(new[] { -56, -54,-53,-52, -50 }, "-56,-54--52,-50")]
+        public void RandomTests(int[] numbers, string expected)
+        {
+            _sut.Extract(numbers).Should().Be(expected);
+        }
+    }
+}

--- a/src/csharp/CodingKata.Exercise/CodeWars/Benchmarks/RangeExtractionBenchmark.cs
+++ b/src/csharp/CodingKata.Exercise/CodeWars/Benchmarks/RangeExtractionBenchmark.cs
@@ -1,0 +1,30 @@
+﻿using BenchmarkDotNet.Attributes;
+using CodingKata.Exercise.Benchmark;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodingKata.Exercise.CodeWars.Benchmarks
+{
+    public class RangeExtractionBenchmark : IBestVoteComparisonBenchmark
+    {
+        [Params(new[] { -6, -3, -2, -1, 0, 1, 3, 4, 5, 7, 8, 9, 10, 11, 14, 15, 17, 18, 19, 20 },
+            new[] { -3, -2, -1, 2, 10, 15, 16, 18, 19, 20 },
+            new[] { 1, 2 })]
+        public int[] Numbers { get; set; }
+
+        [Benchmark(Baseline = true)]
+        public void MySolution()
+        {
+            new RangeExtraction.Kata().Extract(Numbers);
+        }
+
+        [Benchmark]
+        public void BestVote()
+        {
+            new RangeExtraction.KataBestVote().Extract(Numbers);
+        }
+    }
+}

--- a/src/csharp/CodingKata.Exercise/CodeWars/RangeExtraction.cs
+++ b/src/csharp/CodingKata.Exercise/CodeWars/RangeExtraction.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodingKata.Exercise.CodeWars.RangeExtraction
+{
+    public interface IRangeExtraction
+    {
+        string Extract(int[] args);
+    }
+
+    public class Kata : IRangeExtraction
+    {
+        public string Extract(int[] args)
+        {
+            const char RangeNotation = '-';
+            const char NumberDelimeter = ',';
+            int[] numbers = args;
+            if (numbers == null || numbers.Length == 0)
+                return string.Empty;
+
+            if (numbers.Length == 1)
+                return args[0].ToString();
+            if (numbers.Length == 2) 
+                return string.Join(NumberDelimeter, numbers);
+            StringBuilder output = new StringBuilder(numbers[0].ToString());
+            int counter = 1;
+            int previousNumber = numbers[0];
+            for (int i = 1; i < numbers.Length; i++)
+            {
+                int currentNumber = numbers[i];
+                if (currentNumber == previousNumber + 1)
+                {
+                    counter++;
+                }
+                else if(i != numbers.Length - 1)
+                {
+                    if (counter > 2)
+                    {
+                        output.Append(RangeNotation);
+                        output.Append(previousNumber);
+                    }
+                    else if (counter > 1)
+                    {
+                        output.Append(NumberDelimeter);
+                        output.Append(previousNumber);
+                    }
+                    output.Append(NumberDelimeter);
+                    output.Append(currentNumber);
+                    counter = 1;
+                }
+
+                if (i == numbers.Length - 1)
+                {
+                    if (counter > 2)
+                    {
+                        if (currentNumber != previousNumber + 1)
+                        {
+                            output.Append(RangeNotation).Append(previousNumber).Append(NumberDelimeter).Append(currentNumber);
+                        } 
+                        else
+                        {
+                            output.Append(RangeNotation);
+                            output.Append(currentNumber);
+                        }
+                    }
+                    else 
+                    {
+                        if (counter == 2 && currentNumber != previousNumber + 1)
+                        {
+                            output.Append(NumberDelimeter);
+                            output.Append(previousNumber);
+                        }
+                        output.Append(NumberDelimeter);
+                        output.Append(currentNumber);  
+                    }
+                }
+
+                previousNumber = currentNumber;
+            }
+
+            return output.ToString();
+        }
+    }
+
+    public class KataBestVote : IRangeExtraction
+    {
+        public int Value, Count;
+        public int NextValue => Value + Count;
+        public KataBestVote()
+        {
+
+        }
+
+        public KataBestVote(int value)
+        {
+            Value = value;
+            Count = 1;
+        }
+
+        public override string ToString()
+            => Count == 1 ? $"{Value}" :
+               Count == 2 ? $"{Value},{Value + 1}" :
+                            $"{Value}-{NextValue - 1}";
+
+        public string Extract(int[] args)
+        {
+            var list = new List<KataBestVote>();
+
+            foreach (var n in args)
+                if (list.LastOrDefault()?.NextValue == n) list.Last().Count++;
+                else list.Add(new KataBestVote(n));
+
+            return string.Join(",", list);
+        }
+    }
+}

--- a/src/csharp/CodingKata.Exercise/Program.cs
+++ b/src/csharp/CodingKata.Exercise/Program.cs
@@ -9,11 +9,12 @@ namespace CodingKata.Exercise
     {
         static void Main(string[] args)
         {
-            BenchmarkDotNet.Running.BenchmarkRunner.Run<BitCountingBenchmark>(DefaultConfig());
-            BenchmarkDotNet.Running.BenchmarkRunner.Run<MorseCodeDecoderBenchmark>(DefaultConfig());
-            BenchmarkDotNet.Running.BenchmarkRunner.Run<MorseCodeDecoderAdvanceBenchmark>(DefaultConfig());
-            BenchmarkDotNet.Running.BenchmarkRunner.Run<MorseCodeDecoderRealLifeBenchmark>(DefaultConfig());
-            BenchmarkDotNet.Running.BenchmarkRunner.Run<StripCommentsBenchmark>(DefaultConfig());
+            //BenchmarkDotNet.Running.BenchmarkRunner.Run<BitCountingBenchmark>(DefaultConfig());
+            //BenchmarkDotNet.Running.BenchmarkRunner.Run<MorseCodeDecoderBenchmark>(DefaultConfig());
+            //BenchmarkDotNet.Running.BenchmarkRunner.Run<MorseCodeDecoderAdvanceBenchmark>(DefaultConfig());
+            //BenchmarkDotNet.Running.BenchmarkRunner.Run<MorseCodeDecoderRealLifeBenchmark>(DefaultConfig());
+            //BenchmarkDotNet.Running.BenchmarkRunner.Run<StripCommentsBenchmark>(DefaultConfig());
+            BenchmarkDotNet.Running.BenchmarkRunner.Run<RangeExtractionBenchmark>(DefaultConfig());
         }
 
         private static ManualConfig DefaultConfig()


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1202 (21H1/May2021Update)
Intel Core i5-6500 CPU 3.20GHz (Skylake), 1 CPU, 4 logical and 4 physical cores
.NET SDK=6.0.100-preview.7.21379.14
  [Host]     : .NET 5.0.9 (5.0.921.35908), X64 RyuJIT
  DefaultJob : .NET 5.0.9 (5.0.921.35908), X64 RyuJIT


```
|     Method |   Numbers |        Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
|----------- |---------- |------------:|---------:|---------:|------:|--------:|-------:|----------:|
| **MySolution** | **Int32[10]** |   **207.78 ns** | **2.831 ns** | **2.364 ns** |  **1.00** |    **0.00** | **0.1070** |     **336 B** |
|   BestVote | Int32[10] |   938.98 ns | 3.784 ns | 3.540 ns |  4.52 |    0.05 | 0.2470 |     776 B |
| **MySolution** | **Int32[20]** |   **253.27 ns** | **1.805 ns** | **1.600 ns** |  **1.22** |    **0.01** | **0.1097** |     **344 B** |
|   BestVote | Int32[20] | 1,451.29 ns | 5.213 ns | 4.876 ns |  6.99 |    0.09 | 0.2918 |     920 B |
| **MySolution** |  **Int32[2]** |    **52.90 ns** | **0.648 ns** | **0.606 ns** |  **0.25** |    **0.00** | **0.0280** |      **88 B** |
|   BestVote |  Int32[2] |   208.69 ns | 0.988 ns | 0.924 ns |  1.00 |    0.01 | 0.0815 |     256 B |
