### PR TITLE
Add more ignore patterns for VS Code and Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -503,3 +503,17 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 # End Python
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+# Mac
+.DS_Store


### PR DESCRIPTION
Update .gitignore to ignore VS Code and Mac generated files